### PR TITLE
feat: added timestamps to the logger

### DIFF
--- a/components/FlexibleContent/Modules/CopyAndImage/CopyAndImage.tsx
+++ b/components/FlexibleContent/Modules/CopyAndImage/CopyAndImage.tsx
@@ -4,6 +4,7 @@ import Button from '@/components/Button/Button';
 import CMSImageBox from '@/components/ImageBox/CMSImageBox';
 
 import { AnimatedElement } from '@/components/AnimatedComponent/AnimatedComponent';
+import { log } from '@/lib/logger';
 import type { SanityImage } from '@/lib/sanity.image';
 import type { ButtonSchemaType } from '@/schemas/objects/button';
 import clsx from 'clsx';
@@ -26,8 +27,7 @@ export default function CopyAndImage(props: CopyAndImageProps) {
     props;
 
   if (!mobileAlignment || !desktopAlignment) {
-    // eslint-disable-next-line no-console
-    console.warn(
+    log.warn(
       '@deprecated A CopyAndImage component is using a depricated schema field. Please update the schema.'
     );
     return <DeprecatedCopyAndImage {...props} />;

--- a/components/FlexibleContent/Modules/Hero/Hero.tsx
+++ b/components/FlexibleContent/Modules/Hero/Hero.tsx
@@ -11,6 +11,7 @@ import {
 import Button from '@/components/Button/Button';
 import ScrollButton from '@/components/Button/ScrollButton';
 import SplineModel from '@/components/SplineScene/SplineScene';
+import { log } from '@/lib/logger';
 import type {
   HeroSchemaType,
   HeroVariantType,
@@ -41,8 +42,7 @@ export default function Hero(props: HeroSchemaType) {
 
   // TODO - Remove DepricatedHero support when all heros are updated
   if (!_variant || !image) {
-    // eslint-disable-next-line no-console
-    console.warn(
+    log.warn(
       '@deprecated A Hero component is using a depricated schema field. Please update the schema.'
     );
 

--- a/components/FlexibleContent/Modules/StatsTiles/StatsTilesServer.tsx
+++ b/components/FlexibleContent/Modules/StatsTiles/StatsTilesServer.tsx
@@ -1,4 +1,5 @@
 import { REVALIDATIONS } from '@/lib/constants';
+import { log } from '@/lib/logger';
 import StatsTiles from './StatsTiles';
 
 async function getData(): Promise<string | null> {
@@ -21,8 +22,7 @@ async function getData(): Promise<string | null> {
     const { nodeCount } = await response.json();
     return String(nodeCount);
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(`internal ${response?.status || ''} error from Data API. Error ${err}`);
+    log.error(`internal ${response?.status || ''} error from Data API. Error ${err}`);
     return null;
   }
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -3,16 +3,21 @@ import { isProduction } from './env';
 
 class Logger {
   static debugEnabled = !isProduction() && process.env.DEBUG_LOG === 'true';
+
+  private getTimestamp(): string {
+    return new Date().toISOString();
+  }
+
   public debug(message: string, ...args: Array<unknown>) {
     if (Logger.debugEnabled) {
-      console.debug(message, ...args);
+      console.debug(`[${this.getTimestamp()}] ${message}`, ...args);
     }
   }
   public info(message: string, ...args: Array<unknown>) {
-    console.info(message, ...args);
+    console.info(`[${this.getTimestamp()}] ${message}`, ...args);
   }
   public error(message: string, ...args: Array<unknown>) {
-    console.error(message, ...args);
+    console.error(`[${this.getTimestamp()}] ${message}`, ...args);
   }
 }
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -19,6 +19,9 @@ class Logger {
   public error(message: string, ...args: Array<unknown>) {
     console.error(`[${this.getTimestamp()}] ${message}`, ...args);
   }
+  public warn(message: string, ...args: Array<unknown>) {
+    console.warn(`[${this.getTimestamp()}] ${message}`, ...args);
+  }
 }
 
 const log = new Logger();


### PR DESCRIPTION
Semiblocked by: https://github.com/session-foundation/session-token-website/pull/2 (We could potentially rebase off main)

Adding a timestamp to the logger is useful if we need to read pm2 logs directly in order to know when things are happening.